### PR TITLE
Set default max_session_duration to 12 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_assuming_role_arns"></a> [assuming\_role\_arns](#input\_assuming\_role\_arns) | Roles that are allowed to assume this role. For example, a GitHub Actions worker has a role. The GHA role needs to be able to assume the state-manager role. | `list(string)` | n/a | yes |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role. | `number` | `43200` | no |
 | <a name="input_name"></a> [name](#input\_name) | Role name | `any` | n/a | yes |
 | <a name="input_read_only_permissions"></a> [read\_only\_permissions](#input\_read\_only\_permissions) | Whether the role should have read-only permissions on the state bucket. It's needed for roles that access the state via terraform\_remote\_state data source. | `bool` | `false` | no |
 | <a name="input_state_bucket"></a> [state\_bucket](#input\_state\_bucket) | Name of the S3 bucket with the state | `any` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,11 @@ locals {
 
 # IAM role
 resource "aws_iam_role" "state-manager" {
-  name               = var.name
-  description        = "Role to manage a terraform state of a repo"
-  assume_role_policy = data.aws_iam_policy_document.assume.json
-  tags               = local.tags
+  name                 = var.name
+  description          = "Role to manage a terraform state of a repo"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = var.max_session_duration
+  tags                 = local.tags
 }
 
 resource "aws_iam_policy" "permissions_ro" {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black ~= 23.0
+black ~= 24.3
 boto3 ~= 1.26
 infrahouse-toolkit ~= 2.3, >= 2.3.1
 myst-parser ~= 2.0

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "assuming_role_arns" {
   type        = list(string)
 }
 
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the specified role."
+  type        = number
+  default     = 12 * 3600
+}
+
 variable "name" {
   description = "Role name"
 }


### PR DESCRIPTION
We don't want a Terraform session to expire during terraform apply.
Setting the default to 12 hours (max possible value and practically, more than enough)
