### PR TITLE
Add AWS provider v6 support with comprehensive testing infrastructure

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 1.3.0
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:README.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:locals.tf]
+search = module_version = "{current_version}"
+replace = module_version = "{new_version}"

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -1,0 +1,51 @@
+name: 'Terraform CI'
+
+on:
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: aws-control
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    name: 'Terraform Test'
+    runs-on: ["self-hosted", "Linux"]
+    timeout-minutes: 120
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      ROLE_ARN: "arn:aws:iam::303467602807:role/state-manager-tester"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          role-session-name: "terraform-ci"
+          aws-region: "us-west-2"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Setup Python Environment
+        run: make bootstrap
+
+      - name: Code Style Check
+        run: make lint
+
+      - name: Terraform Tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+.claude

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ for line in sys.stdin:
 endef
 export PRINT_HELP_PYSCRIPT
 
+TEST_REGION="us-west-2"
+TEST_ROLE="arn:aws:iam::303467602807:role/state-manager-tester"
+
 help: install-hooks
 	@python -c "$$PRINT_HELP_PYSCRIPT" < Makefile
 
@@ -40,6 +43,21 @@ lint:  ## Run code style checks
 test:  ## Run tests on the module
 	pytest -xvvs tests
 
+.PHONY: test-keep
+test-keep: ## Run a test and keep resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		--keep-after \
+		tests/test_module.py
+
+.PHONY: test-clean
+test-clean: ## Run a test and destroy resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		tests/test_module.py
+
 .PHONY: bootstrap
 bootstrap: ## bootstrap the development environment
 	pip install -U "pip ~= 23.1"
@@ -56,10 +74,12 @@ docs: ## generate Sphinx HTML documentation, including API docs
 
 .PHONY: clean
 clean:  ## Remove various artifacts
-	rm -rf test_data/gha-admin/.terraform \
-		test_data/gha-admin/.terraform.lock.hcl \
-		test_data/gha-admin/terraform.tfstate \
-		test_data/gha-admin/terraform.tfstate.backup \
+	rm -rf test_data/state-manager/.terraform \
+		test_data/state-manager/.terraform.lock.hcl \
+		test_data/state-manager/terraform.tfstate \
+		test_data/state-manager/terraform.tfstate.backup \
+		test_data/state-manager/terraform.tfvars \
+		test_data/state-manager/terraform.tf \
 		.pytest_cache \
 		tf-apply-trace.txt \
 		tf-destroy-trace.txt

--- a/README.md
+++ b/README.md
@@ -1,18 +1,85 @@
-# Module state-manager
+# Terraform AWS State Manager
 
-The state-manager role creates an IAM role that can work with a Terraform state file in an S3 bucket.
+This Terraform module creates an IAM role designed to manage Terraform state files stored in S3 with DynamoDB locking.
+The role provides secure, controlled access to state resources while supporting both read-only and read-write permissions.
 
+## Features
+
+- Creates IAM role with configurable assume role policies
+- Supports both read-only and read-write permissions for state management
+- Automatic role name truncation to meet AWS 64-character limit
+- DynamoDB integration for state locking
+- Configurable session duration
+- Comprehensive resource tagging
+
+## Usage
+
+### Basic Configuration
+```hcl
+module "state_manager" {
+  source  = "infrahouse/state-manager/aws"
+  version = "1.3.0"
+
+  name                      = "my-terraform-state-manager"
+  state_bucket              = "my-terraform-state-bucket"
+  terraform_locks_table_arn = "arn:aws:dynamodb:us-west-2:123456789012:table/terraform-locks"
+
+  assuming_role_arns = [
+    "arn:aws:iam::123456789012:role/github-actions-role"
+  ]
+}
+```
+
+### Advanced Configuration with GitHub Actions
+```hcl
+module "state_manager" {
+  source  = "infrahouse/state-manager/aws"
+  version = "1.3.0"
+
+  name = "ih-tf-${var.repo_name}-state-manager"
+
+  assuming_role_arns = concat(
+    [
+      aws_iam_role.github.arn
+    ],
+    var.trusted_arns
+  )
+
+  state_bucket              = var.state_bucket
+  state_key                 = "environments/${terraform.workspace}/terraform.tfstate"
+  terraform_locks_table_arn = var.terraform_locks_table_arn
+  max_session_duration      = 3600  # 1 hour
+  read_only_permissions     = false
+}
+```
+
+### Read-Only State Access
+```hcl
+module "state_reader" {
+  source  = "infrahouse/state-manager/aws"
+  version = "1.3.0"
+
+  name                      = "terraform-state-reader"
+  state_bucket              = "my-terraform-state-bucket" 
+  terraform_locks_table_arn = "arn:aws:dynamodb:us-west-2:123456789012:table/terraform-locks"
+  read_only_permissions     = true
+
+  assuming_role_arns = [
+    "arn:aws:iam::123456789012:role/readonly-access-role"
+  ]
+}
+```
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.11 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
 
 ## Modules
 
@@ -37,14 +104,15 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_assuming_role_arns"></a> [assuming\_role\_arns](#input\_assuming\_role\_arns) | Roles that are allowed to assume this role. For example, a GitHub Actions worker has a role. The GHA role needs to be able to assume the state-manager role. | `list(string)` | n/a | yes |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role. | `number` | `43200` | no |
-| <a name="input_name"></a> [name](#input\_name) | Role name | `any` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Role name | `string` | n/a | yes |
 | <a name="input_read_only_permissions"></a> [read\_only\_permissions](#input\_read\_only\_permissions) | Whether the role should have read-only permissions on the state bucket. It's needed for roles that access the state via terraform\_remote\_state data source. | `bool` | `false` | no |
-| <a name="input_state_bucket"></a> [state\_bucket](#input\_state\_bucket) | Name of the S3 bucket with the state | `any` | n/a | yes |
+| <a name="input_state_bucket"></a> [state\_bucket](#input\_state\_bucket) | Name of the S3 bucket with the state | `string` | n/a | yes |
 | <a name="input_state_key"></a> [state\_key](#input\_state\_key) | Path to the state file in the state bucket | `string` | `"terraform.tfstate"` | no |
-| <a name="input_terraform_locks_table_arn"></a> [terraform\_locks\_table\_arn](#input\_terraform\_locks\_table\_arn) | DynamoDB table that holds Terraform state locks. | `any` | n/a | yes |
+| <a name="input_terraform_locks_table_arn"></a> [terraform\_locks\_table\_arn](#input\_terraform\_locks\_table\_arn) | DynamoDB table that holds Terraform state locks. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_state_manager_role_arn"></a> [state\_manager\_role\_arn](#output\_state\_manager\_role\_arn) | ARN of the created state manager role. |
+| <a name="output_state_manager_role_name"></a> [state\_manager\_role\_name](#output\_state\_manager\_role\_name) | Name of the created state manager role. |

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  module_version = "1.3.0"
   tags = {
     created_by_module : "infrahouse/state-manager/aws"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,16 @@ locals {
 
 # IAM role
 resource "aws_iam_role" "state-manager" {
-  name                 = var.name
+  name                 = substr(var.name, 0, 64)
   description          = "Role to manage a terraform state of a repo"
   assume_role_policy   = data.aws_iam_policy_document.assume.json
   max_session_duration = var.max_session_duration
-  tags                 = local.tags
+  tags = merge(
+    local.tags,
+    {
+      module_version : local.module_version
+    }
+  )
 }
 
 resource "aws_iam_policy" "permissions_ro" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "state_manager_role_arn" {
   description = "ARN of the created state manager role."
   value       = aws_iam_role.state-manager.arn
 }
+
+output "state_manager_role_name" {
+  description = "Name of the created state manager role."
+  value       = aws_iam_role.state-manager.name
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
-black ~= 24.3
-boto3 ~= 1.26
-infrahouse-toolkit ~= 2.3, >= 2.3.1
-myst-parser ~= 2.0
-pytest ~= 7.3
-Sphinx ~= 6.0
-sphinx-rtd-theme ~= 1.2
+infrahouse-core ~= 0.17
+pytest-infrahouse ~= 0.10

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
+      version = ">= 5.11, < 7.0"
     }
   }
 }

--- a/test_data/state-manager/.gitignore
+++ b/test_data/state-manager/.gitignore
@@ -1,0 +1,7 @@
+.terraform
+.terraform.tfstate.lock.info
+terraform.tfvars
+terraform.tf
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup

--- a/test_data/state-manager/main.tf
+++ b/test_data/state-manager/main.tf
@@ -1,0 +1,11 @@
+module "test" {
+  source = "../.."
+
+  assuming_role_arns        = var.assuming_role_arns
+  max_session_duration      = var.max_session_duration
+  name                      = var.name
+  read_only_permissions     = var.read_only_permissions
+  state_bucket              = var.state_bucket
+  state_key                 = var.state_key
+  terraform_locks_table_arn = var.terraform_locks_table_arn
+}

--- a/test_data/state-manager/outputs.tf
+++ b/test_data/state-manager/outputs.tf
@@ -1,0 +1,7 @@
+output "state_manager_role_arn" {
+  value = module.test.state_manager_role_arn
+}
+
+output "state_manager_role_name" {
+  value = module.test.state_manager_role_name
+}

--- a/test_data/state-manager/providers.tf
+++ b/test_data/state-manager/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = var.region
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  default_tags {
+    tags = {
+      "created_by" : "infrahouse/terraform-aws-state-manager" # GitHub repository that created a resource
+    }
+
+  }
+}

--- a/test_data/state-manager/variables.tf
+++ b/test_data/state-manager/variables.tf
@@ -1,10 +1,15 @@
+variable "region" {}
+variable "role_arn" {
+  default = null
+}
+
 variable "assuming_role_arns" {
-  description = "Roles that are allowed to assume this role. For example, a GitHub Actions worker has a role. The GHA role needs to be able to assume the state-manager role."
+  description = "Roles that are allowed to assume this role"
   type        = list(string)
 }
 
 variable "max_session_duration" {
-  description = "Maximum session duration (in seconds) that you want to set for the specified role."
+  description = "Maximum session duration (in seconds)"
   type        = number
   default     = 12 * 3600
 }
@@ -13,8 +18,9 @@ variable "name" {
   description = "Role name"
   type        = string
 }
+
 variable "read_only_permissions" {
-  description = "Whether the role should have read-only permissions on the state bucket. It's needed for roles that access the state via terraform_remote_state data source."
+  description = "Whether the role should have read-only permissions"
   type        = bool
   default     = false
 }
@@ -31,6 +37,6 @@ variable "state_key" {
 }
 
 variable "terraform_locks_table_arn" {
-  description = "DynamoDB table that holds Terraform state locks."
+  description = "DynamoDB table that holds Terraform state locks"
   type        = string
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.pytest_cache/
+*.egg-info/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import logging
+from infrahouse_core.logging import setup_logging
+
+LOG = logging.getLogger()
+TERRAFORM_ROOT_DIR = "test_data"
+
+setup_logging(LOG, debug=True)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,178 @@
+from os import path as osp, remove
+import json
+from textwrap import dedent
+
+import pytest
+from pytest_infrahouse import terraform_apply
+
+from tests.conftest import LOG, TERRAFORM_ROOT_DIR
+
+
+@pytest.mark.parametrize("aws_provider_version", ["~> 5.11", "~> 6.0"])
+@pytest.mark.parametrize(
+    "name, read_only",
+    [
+        ("state-manager-test", False),
+        ("state-manager-ro-test", True),
+        (
+            "state-manager-very-long-name-that-exceeds-typical-aws-limits-but-should-still-work",
+            False,
+        ),
+    ],
+)
+def test_module(
+    aws_provider_version,
+    name,
+    read_only,
+    aws_region,
+    test_role_arn,
+    keep_after,
+    boto3_session,
+):
+    terraform_dir = f"{TERRAFORM_ROOT_DIR}/state-manager"
+
+    # Delete .terraform.lock.hcl to allow provider version changes
+    lock_file_path = osp.join(terraform_dir, ".terraform.lock.hcl")
+    try:
+        remove(lock_file_path)
+    except FileNotFoundError:
+        pass
+
+    # Update provider version
+    with open(f"{terraform_dir}/terraform.tf", "w") as fp:
+        fp.write(
+            f"""
+            terraform {{
+                required_version = "~> 1.0"
+                required_providers {{
+                    aws = {{
+                      source  = "hashicorp/aws"
+                      version = "{aws_provider_version}"
+                    }}
+                  }}
+                }}
+            """
+        )
+
+    # Get AWS account ID
+    sts = boto3_session.client("sts", region_name=aws_region)
+    account_id = sts.get_caller_identity()["Account"]
+    # Write test variables
+    assuming_role_arn = (
+        test_role_arn or f"arn:aws:iam::{account_id}:role/state-manager-tester"
+    )
+
+    with open(f"{terraform_dir}/terraform.tfvars", "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                assuming_role_arns = ["{assuming_role_arn}"]
+                name = "{name}"
+                read_only_permissions = {str(read_only).lower()}
+                state_bucket = "test-state-bucket"
+                state_key = "test/terraform.tfstate"
+                terraform_locks_table_arn = "arn:aws:dynamodb:{aws_region}:{account_id}:table/terraform-locks"
+                """
+            )
+        )
+        fp.write(
+            dedent(
+                f"""
+                region       = "{aws_region}"
+                """
+            )
+        )
+        if test_role_arn:
+            fp.write(
+                dedent(
+                    f"""
+                    role_arn     = "{test_role_arn}"
+                    """
+                )
+            )
+
+    with terraform_apply(
+        terraform_dir, destroy_after=not keep_after, json_output=True
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4, default=str))
+
+        # Verify outputs exist
+        assert "state_manager_role_arn" in tf_output
+        assert tf_output["state_manager_role_arn"]["value"].startswith("arn:aws:iam::")
+        assert name.startswith(tf_output["state_manager_role_name"]["value"])
+
+
+@pytest.mark.parametrize("aws_provider_version", ["~> 5.11", "~> 6.0"])
+def test_module_defaults(
+    aws_provider_version, aws_region, test_role_arn, keep_after, boto3_session
+):
+    """Test module with default values where applicable"""
+    terraform_dir = f"{TERRAFORM_ROOT_DIR}/state-manager"
+
+    # Delete .terraform.lock.hcl to allow provider version changes
+    lock_file_path = osp.join(terraform_dir, ".terraform.lock.hcl")
+    try:
+        remove(lock_file_path)
+    except FileNotFoundError:
+        pass
+
+    # Update provider version
+    with open(f"{terraform_dir}/terraform.tf", "w") as fp:
+        fp.write(
+            f"""
+            terraform {{
+                required_version = "~> 1.0"
+                required_providers {{
+                    aws = {{
+                      source  = "hashicorp/aws"
+                      version = "{aws_provider_version}"
+                    }}
+                  }}
+                }}
+            """
+        )
+
+    # Get AWS account ID
+    sts = boto3_session.client("sts", region_name=aws_region)
+    account_id = sts.get_caller_identity()["Account"]
+
+    # Write minimal required variables, let defaults take effect
+    assuming_role_arn = (
+        test_role_arn or f"arn:aws:iam::{account_id}:role/state-manager-tester"
+    )
+    with open(f"{terraform_dir}/terraform.tfvars", "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                assuming_role_arns = ["{assuming_role_arn}"]
+                name = "state-manager-defaults"
+                state_bucket = "test-state-bucket"
+                terraform_locks_table_arn = "arn:aws:dynamodb:{aws_region}:{account_id}:table/terraform-locks"
+                """
+            )
+        )
+        fp.write(
+            dedent(
+                f"""
+                region       = "{aws_region}"
+                """
+            )
+        )
+        if test_role_arn:
+            fp.write(
+                dedent(
+                    f"""
+                    role_arn     = "{test_role_arn}"
+                    """
+                )
+            )
+
+    with terraform_apply(
+        terraform_dir, destroy_after=not keep_after, json_output=True
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4, default=str))
+
+        # Verify outputs exist
+        assert "state_manager_role_arn" in tf_output
+        assert tf_output["state_manager_role_arn"]["value"].startswith("arn:aws:iam::")
+        assert "state-manager-defaults" in tf_output["state_manager_role_arn"]["value"]


### PR DESCRIPTION
- Add pytest-based test suite with parametrized tests for AWS provider versions ~> 5.11 and ~> 6.0
- Create test_data configuration for module testing
- Add Makefile targets: test-keep, test-clean for manual testing
- Add GitHub Actions CI workflow (terraform-CI.yml)
- Add bumpversion configuration for version management
- Implement role name truncation to 64 characters for AWS limits
- Enhance README with features section and multiple usage examples
-  Add missing type declarations to variables.tf
