### PR TITLE
feat: support wildcard principal patterns in trust policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 .claude
+pytest-*-output.log

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ test-keep: ## Run a test and keep resources
 		--test-role-arn=${TEST_ROLE} \
 		--keep-after \
 		$(if ${TEST_FILTER},-k "${TEST_FILTER}") \
-		tests/test_module.py
+		tests/test_module.py \
+		2>&1 | tee pytest-`date +%Y%m%d-%H%M%S`-output.log
 
 .PHONY: test-clean
 test-clean: ## Run a test and destroy resources
@@ -56,7 +57,8 @@ test-clean: ## Run a test and destroy resources
 		--aws-region=${TEST_REGION} \
 		--test-role-arn=${TEST_ROLE} \
 		$(if ${TEST_FILTER},-k "${TEST_FILTER}") \
-		tests/test_module.py
+		tests/test_module.py \
+		2>&1 | tee pytest-`date +%Y%m%d-%H%M%S`-output.log
 
 .PHONY: bootstrap
 bootstrap: install-hooks ## bootstrap the development environment

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The role provides secure, controlled access to state resources while supporting 
 
 - Creates IAM role with configurable assume role policies
 - Supports both read-only and read-write permissions for state management
+- Wildcard principal matching via `assuming_role_patterns` (useful for AWS SSO roles)
 - Automatic role name truncation to meet AWS 64-character limit
 - DynamoDB integration for state locking
 - Configurable session duration
@@ -62,6 +63,27 @@ module "state_manager" {
   terraform_locks_table_arn = var.terraform_locks_table_arn
   max_session_duration      = 3600  # 1 hour
   read_only_permissions     = false
+}
+```
+
+### SSO Role Access with Wildcard Patterns
+```hcl
+module "state_manager" {
+  source  = "infrahouse/state-manager/aws"
+  version = "1.4.2"
+
+  name                      = "my-terraform-state-manager"
+  environment               = var.environment
+  state_bucket              = "my-terraform-state-bucket"
+  terraform_locks_table_arn = "arn:aws:dynamodb:us-west-2:123456789012:table/terraform-locks"
+
+  assuming_role_arns = [
+    "arn:aws:iam::123456789012:role/github-actions-role"
+  ]
+
+  assuming_role_patterns = [
+    "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"
+  ]
 }
 ```
 

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -7,6 +7,23 @@ data "aws_iam_policy_document" "assume" {
       identifiers = var.assuming_role_arns
     }
   }
+
+  dynamic "statement" {
+    for_each = length(var.assuming_role_patterns) > 0 ? [1] : []
+    content {
+      sid     = "001"
+      actions = ["sts:AssumeRole"]
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringLike"
+        variable = "aws:PrincipalArn"
+        values   = var.assuming_role_patterns
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "permissions_ro" {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,24 @@ assuming_role_arns = [
 ]
 ```
 
+### `assuming_role_patterns`
+
+- **Type:** `list(string)`
+- **Default:** `[]`
+
+ARN patterns with wildcards for roles allowed to assume this role. Uses a `StringLike`
+condition on `aws:PrincipalArn` instead of exact matching. This is useful for AWS SSO
+roles, which have auto-generated suffixes that change when permission sets are recreated.
+
+```hcl
+assuming_role_patterns = [
+  "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"
+]
+```
+
+Can be used alongside `assuming_role_arns` — exact ARNs are matched by the trust policy's
+principal list, while patterns are matched via a `StringLike` condition.
+
 ## Optional Variables
 
 ### `read_only_permissions`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -40,6 +40,30 @@ module "state_reader" {
 }
 ```
 
+## AWS SSO Access with Wildcard Patterns
+
+Allow SSO roles to manage state without hardcoding the full ARN. SSO role suffixes
+change when permission sets are recreated — wildcard patterns avoid breakage.
+
+```hcl
+module "state_manager" {
+  source  = "registry.infrahouse.com/infrahouse/state-manager/aws"
+  version = "1.4.2"
+
+  name                      = "my-terraform-state-manager"
+  state_bucket              = "my-terraform-state-bucket"
+  terraform_locks_table_arn = "arn:aws:dynamodb:us-west-2:123456789012:table/terraform-locks"
+
+  assuming_role_arns = [
+    "arn:aws:iam::123456789012:role/github-actions-role"
+  ]
+
+  assuming_role_patterns = [
+    "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"
+  ]
+}
+```
+
 ## GitHub Actions Integration
 
 Create a state manager role alongside a GitHub Actions identity, with a custom

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ resources with support for both read-only and read-write permission modes.
 - **Read-Only Mode** - Grant `terraform_remote_state` access without write or lock
   permissions
 - **Read-Write Mode** - Full state management with S3 put/delete and DynamoDB locking
+- **Wildcard Principal Matching** - Support for `assuming_role_patterns` with
+  `StringLike` conditions, useful for AWS SSO roles with auto-generated suffixes
 - **Automatic Name Truncation** - Role names exceeding 64 characters are automatically
   truncated to meet the AWS limit
 - **Configurable Session Duration** - Control how long assumed sessions last

--- a/test_data/state-manager/main.tf
+++ b/test_data/state-manager/main.tf
@@ -26,6 +26,7 @@ module "test" {
 
   environment               = var.environment
   assuming_role_arns        = var.assuming_role_arns
+  assuming_role_patterns    = var.assuming_role_patterns
   max_session_duration      = var.max_session_duration
   name                      = var.name
   read_only_permissions     = var.read_only_permissions

--- a/test_data/state-manager/main.tf
+++ b/test_data/state-manager/main.tf
@@ -1,12 +1,9 @@
-data "aws_caller_identity" "current" {}
-
 locals {
-  bucket_name = "${substr(var.name, 0, 40)}-${data.aws_caller_identity.current.account_id}"
-  table_name  = "${substr(var.name, 0, 40)}-locks"
+  table_name = "${substr(var.name, 0, 40)}-locks"
 }
 
 resource "aws_s3_bucket" "state" {
-  bucket        = local.bucket_name
+  bucket_prefix = "${substr(var.name, 0, 37)}-"
   force_destroy = true
 }
 

--- a/test_data/state-manager/main.tf
+++ b/test_data/state-manager/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_s3_bucket" "state" {
-  bucket_prefix = "${substr(var.name, 0, 37)}-"
+  bucket_prefix = "${substr(var.name, 0, 36)}-"
   force_destroy = true
 }
 

--- a/test_data/state-manager/variables.tf
+++ b/test_data/state-manager/variables.tf
@@ -13,6 +13,12 @@ variable "assuming_role_arns" {
   type        = list(string)
 }
 
+variable "assuming_role_patterns" {
+  description = "ARN patterns with wildcards for roles allowed to assume this role"
+  type        = list(string)
+  default     = []
+}
+
 variable "max_session_duration" {
   description = "Maximum session duration (in seconds)"
   type        = number

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -234,7 +234,7 @@ def _verify_permissions(
     # Retry for IAM policy propagation — any action can fail until
     # all policy attachments have propagated.
     sleep_time = 2
-    with timeout(seconds=60):
+    with timeout(seconds=120):
         while True:
             try:
                 if not read_only:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -397,16 +397,25 @@ def test_module_wildcard(
     _write_provider_version(terraform_dir, aws_provider_version)
 
     probe_role_arn = probe_role["role_arn"]["value"]
-    # Derive a wildcard pattern from the probe role ARN
-    # e.g. arn:aws:iam::123456789012:role/pytest-probe-*
     probe_role_pattern = probe_role_arn.rsplit("-", 1)[0] + "-*"
+
+    sts = boto3_session.client("sts", region_name=aws_region)
+    caller_arn = sts.get_caller_identity()["Arn"]
+    # Convert assumed-role ARN to role ARN for the trust policy
+    if ":assumed-role/" in caller_arn:
+        parts = caller_arn.split(":")
+        account_id = parts[4]
+        role_name = parts[5].split("/")[1]
+        caller_role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+    else:
+        caller_role_arn = caller_arn
 
     _write_tfvars(
         terraform_dir,
         aws_region,
         test_role_arn,
         "state-manager-wildcard",
-        assuming_role_arns=[test_role_arn],
+        assuming_role_arns=[caller_role_arn],
         assuming_role_patterns=[probe_role_pattern],
     )
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -401,12 +401,13 @@ def test_module_wildcard(
 
     sts = boto3_session.client("sts", region_name=aws_region)
     caller_arn = sts.get_caller_identity()["Arn"]
-    # Convert assumed-role ARN to role ARN for the trust policy
+    # Resolve full role ARN via IAM — assumed-role ARNs strip the
+    # IAM path (e.g. SSO's aws-reserved/sso.amazonaws.com/<region>/)
+    # so reconstructing from the ARN string gives an invalid principal.
     if ":assumed-role/" in caller_arn:
-        parts = caller_arn.split(":")
-        account_id = parts[4]
-        role_name = parts[5].split("/")[1]
-        caller_role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+        role_name = caller_arn.split(":")[5].split("/")[1]
+        iam = boto3_session.client("iam", region_name=aws_region)
+        caller_role_arn = iam.get_role(RoleName=role_name)["Role"]["Arn"]
     else:
         caller_role_arn = caller_arn
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -41,6 +41,7 @@ def _write_tfvars(
     test_role_arn: Optional[str],
     name: str,
     assuming_role_arns: List[str],
+    assuming_role_patterns: Optional[List[str]] = None,
     read_only: bool = False,
 ) -> None:
     """Write terraform.tfvars for a test run."""
@@ -54,6 +55,9 @@ def _write_tfvars(
                 read_only_permissions = {str(read_only).lower()}
                 region = "{aws_region}"
                 """))
+        if assuming_role_patterns is not None:
+            patterns_str = ", ".join(f'"{p}"' for p in assuming_role_patterns)
+            fp.write(f'assuming_role_patterns = [{patterns_str}]\n')
         if test_role_arn:
             fp.write(f'role_arn = "{test_role_arn}"\n')
 
@@ -365,6 +369,45 @@ def test_module_aws5_compat(
         test_role_arn,
         "state-manager-aws5-compat",
         assuming_role_arns=[probe_role_arn],
+    )
+
+    with terraform_apply(
+        terraform_dir, destroy_after=not keep_after, json_output=True
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4, default=str))
+
+        assert "state_manager_role_arn" in tf_output
+        assert tf_output["state_manager_role_arn"]["value"].startswith("arn:aws:iam::")
+
+        _verify_permissions(boto3_session, aws_region, probe_role, tf_output)
+
+
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
+def test_module_wildcard(
+    aws_provider_version,
+    aws_region,
+    test_role_arn,
+    keep_after,
+    boto3_session,
+    probe_role,
+):
+    """Test assuming_role_patterns with wildcard principal matching."""
+    terraform_dir = f"{TERRAFORM_ROOT_DIR}/state-manager"
+
+    _write_provider_version(terraform_dir, aws_provider_version)
+
+    probe_role_arn = probe_role["role_arn"]["value"]
+    # Derive a wildcard pattern from the probe role ARN
+    # e.g. arn:aws:iam::123456789012:role/pytest-probe-*
+    probe_role_pattern = probe_role_arn.rsplit("-", 1)[0] + "-*"
+
+    _write_tfvars(
+        terraform_dir,
+        aws_region,
+        test_role_arn,
+        "state-manager-wildcard",
+        assuming_role_arns=[test_role_arn],
+        assuming_role_patterns=[probe_role_pattern],
     )
 
     with terraform_apply(

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,17 @@ variable "assuming_role_arns" {
   }
 }
 
+variable "assuming_role_patterns" {
+  description = <<-EOT
+    ARN patterns (with wildcards) for roles allowed to assume this role.
+    Uses StringLike condition on aws:PrincipalArn instead of exact matching.
+    Useful for AWS SSO roles with auto-generated suffixes.
+    Example: ["arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"]
+  EOT
+  type        = list(string)
+  default     = []
+}
+
 variable "environment" {
   description = "Environment name (e.g., development, staging, production)."
   type        = string


### PR DESCRIPTION
## Summary

- Add `assuming_role_patterns` variable that uses `StringLike` condition on `aws:PrincipalArn` for wildcard matching
- Useful for AWS SSO roles with auto-generated suffixes that change when permission sets are recreated
- Can be used alongside `assuming_role_arns` — exact ARNs use principal matching, patterns use `StringLike` condition
- Save pytest output to timestamped log files in `test-keep` and `test-clean` targets

## Example

```hcl
assuming_role_patterns = [
  "arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess_*"
]
```

Closes #22

## Test plan

- [x] `test_module_wildcard` — creates role with wildcard pattern, verifies probe role can assume via pattern and exercise S3/DynamoDB permissions
- [x] Existing tests pass (no breaking changes — `assuming_role_patterns` defaults to `[]`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)